### PR TITLE
Update auth method

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,8 @@ This is a specialized tool for aggregating Bugzilla records in a way that is use
 
 1. This utility depends on a python-based tool called [python-bugzilla](https://pypi.python.org/pypi/python-bugzilla).
     * Install it so that the `bugzilla` executable is in your $PATH
-    * Configure it by running `bugzilla login`
+    * Configure the API key by running `bugzilla login --api-key` and providing the API Key (interactive only)
+    * Alternatively, you can edit `~/.config/python-bugzilla/bugzillarc` to add it manually. See `man bugzilla` for formatting.
 2. Next grab this utility from RubyGems:
     * gem install shiftzilla
     * Run any command (like `shiftzilla summary`) to have the utility set up your local $HOME/.shiftzilla directory

--- a/lib/shiftzilla/source.rb
+++ b/lib/shiftzilla/source.rb
@@ -26,7 +26,7 @@ module Shiftzilla
       table_fields  = @fields.map{ |fld| "\"#{field_map[fld]}\"" }.join(',')
       insert_frame  = @fields.map{ |fld| '?' }.join(', ')
       # Previous bz_command that used the savedsearch provided by the config
-      #bz_command    = "bugzilla query --savedsearch #{@search} --savedsearch-sharer-id=#{@sharer} --outputformat='#{output_format}\x1F%{flags}flags||EOR'"
+      #bz_command    = "bugzilla --ensure-logged-in query --savedsearch #{@search} --savedsearch-sharer-id=#{@sharer} --outputformat='#{output_format}\x1F%{flags}flags||EOR'"
       retrieved     = []
       bz_page_size  = 1000
       offset        = 0
@@ -37,7 +37,7 @@ module Shiftzilla
       begin
         # Generate the query via string interpolation and execute
         # Query needs to be hard-coded here for string interpolation
-        bz_command = "bugzilla query --from-url 'https://bugzilla.redhat.com/buglist.cgi?bug_severity=unspecified&bug_severity=urgent&bug_severity=high&bug_severity=medium&bug_status=NEW&bug_status=ASSIGNED&bug_status=POST&bug_status=ON_DEV&classification=Red%20Hat&columnlist=short_desc%2Cversion%2Cbug_severity%2Cpriority%2Ccomponent%2Creporter%2Cassigned_to%2Cqa_contact%2Cbug_status%2Cproduct%2Cchangeddate%2Ctarget_release%2Ckeywords%2Cflagtypes.name%2Cbug_file_loc%2Cext_bz_list&f1=component&f10=target_release&f11=target_release&f2=component&f3=version&f4=target_release&f5=target_release&f6=target_release&f7=short_desc&f8=target_release&f9=short_desc&limit=#{bz_page_size}&list_id=12103836&o1=notequals&o10=notsubstring&o11=notsubstring&o2=notequals&o3=notregexp&o4=notsubstring&o5=notsubstring&o6=notsubstring&o7=notsubstring&o8=notsubstring&o9=notsubstring&offset=#{offset}&order=bug_status%2Cpriority%2Cassigned_to%2Cbug_id&product=OKD&product=OpenShift%20Container%20Platform&query_format=advanced&v1=Documentation&v2=RFE&v3=%5E2%5C.' --outputformat='#{output_format}\x1F%{flags}flags||EOR'"
+        bz_command = "bugzilla --ensure-logged-in query --from-url 'https://bugzilla.redhat.com/buglist.cgi?bug_severity=unspecified&bug_severity=urgent&bug_severity=high&bug_severity=medium&bug_status=NEW&bug_status=ASSIGNED&bug_status=POST&bug_status=ON_DEV&classification=Red%20Hat&columnlist=short_desc%2Cversion%2Cbug_severity%2Cpriority%2Ccomponent%2Creporter%2Cassigned_to%2Cqa_contact%2Cbug_status%2Cproduct%2Cchangeddate%2Ctarget_release%2Ckeywords%2Cflagtypes.name%2Cbug_file_loc%2Cext_bz_list&f1=component&f10=target_release&f11=target_release&f2=component&f3=version&f4=target_release&f5=target_release&f6=target_release&f7=short_desc&f8=target_release&f9=short_desc&limit=#{bz_page_size}&list_id=12103836&o1=notequals&o10=notsubstring&o11=notsubstring&o2=notequals&o3=notregexp&o4=notsubstring&o5=notsubstring&o6=notsubstring&o7=notsubstring&o8=notsubstring&o9=notsubstring&offset=#{offset}&order=bug_status%2Cpriority%2Cassigned_to%2Cbug_id&product=OKD&product=OpenShift%20Container%20Platform&query_format=advanced&v1=Documentation&v2=RFE&v3=%5E2%5C.' --outputformat='#{output_format}\x1F%{flags}flags||EOR'"
         bz_csv_inner = `#{bz_command}`
 
         # Shovel results into bz_csv to parse later

--- a/lib/shiftzilla/version.rb
+++ b/lib/shiftzilla/version.rb
@@ -1,3 +1,3 @@
 module Shiftzilla
-  VERSION = "0.2.32"
+  VERSION = "0.2.33"
 end


### PR DESCRIPTION
Bugzilla is dropping support for the credentials login method in favor of API keys.

* Update README to reflect new changes
* Add `--ensure-login` flag to avoid bad data
* Version bump